### PR TITLE
Add example carousel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,3 +61,18 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.3s ease-in-out;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useChat } from "@ai-sdk/react";
 import clsx from "clsx";
 import { LoadingCircle, SendIcon } from "./icons";
-import { Bot, User } from "lucide-react";
+import { Bot, User, ChevronLeft, ChevronRight } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
@@ -35,6 +35,15 @@ export default function Chat() {
       }
     },
   });
+
+  const [exampleIndex, setExampleIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setExampleIndex((i) => (i + 1) % examples.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
 
   const disabled = isLoading || input.length === 0;
 
@@ -201,18 +210,38 @@ export default function Chat() {
             </div>
           </div>
           <div className="flex flex-col space-y-4 border-t border-gray-200 bg-gray-50 p-7 sm:p-10">
-            {examples.map((example, i) => (
+            <div className="flex items-center justify-center space-x-2">
               <button
-                key={i}
+                onClick={() =>
+                  setExampleIndex(
+                    (exampleIndex - 1 + examples.length) % examples.length
+                  )
+                }
+                className="rounded-full p-2 text-gray-500 hover:text-black"
+                aria-label="Previous example"
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </button>
+              <button
+                key={exampleIndex}
                 className="rounded-md border border-gray-200 bg-white px-5 py-3 text-left text-sm text-gray-500 transition-all duration-75 hover:border-black hover:text-gray-700 active:bg-gray-50"
                 onClick={() => {
-                  setInput(example);
+                  setInput(examples[exampleIndex]);
                   inputRef.current?.focus();
                 }}
               >
-                {example}
+                {examples[exampleIndex]}
               </button>
-            ))}
+              <button
+                onClick={() =>
+                  setExampleIndex((exampleIndex + 1) % examples.length)
+                }
+                className="rounded-full p-2 text-gray-500 hover:text-black"
+                aria-label="Next example"
+              >
+                <ChevronRight className="h-5 w-5" />
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,12 +37,24 @@ export default function Chat() {
   });
 
   const [exampleIndex, setExampleIndex] = useState(0);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  useEffect(() => {
-    const interval = setInterval(() => {
+  const startInterval = () => {
+    intervalRef.current = setInterval(() => {
       setExampleIndex((i) => (i + 1) % examples.length);
     }, 5000);
-    return () => clearInterval(interval);
+  };
+
+  const restartInterval = () => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    startInterval();
+  };
+
+  useEffect(() => {
+    startInterval();
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
   }, []);
 
   const disabled = isLoading || input.length === 0;
@@ -212,11 +224,12 @@ export default function Chat() {
           <div className="flex flex-col space-y-4 border-t border-gray-200 bg-gray-50 p-7 sm:p-10">
             <div className="flex items-center justify-center space-x-2">
               <button
-                onClick={() =>
+                onClick={() => {
                   setExampleIndex(
                     (exampleIndex - 1 + examples.length) % examples.length
-                  )
-                }
+                  );
+                  restartInterval();
+                }}
                 className="rounded-full p-2 text-gray-500 hover:text-black"
                 aria-label="Previous example"
               >
@@ -224,7 +237,7 @@ export default function Chat() {
               </button>
               <button
                 key={exampleIndex}
-                className="rounded-md border border-gray-200 bg-white px-5 py-3 text-left text-sm text-gray-500 transition-all duration-75 hover:border-black hover:text-gray-700 active:bg-gray-50"
+                className="animate-fade-in rounded-md border border-gray-200 bg-white px-5 py-3 text-left text-sm text-gray-500 transition-all duration-75 hover:border-black hover:text-gray-700 active:bg-gray-50"
                 onClick={() => {
                   setInput(examples[exampleIndex]);
                   inputRef.current?.focus();
@@ -233,9 +246,10 @@ export default function Chat() {
                 {examples[exampleIndex]}
               </button>
               <button
-                onClick={() =>
-                  setExampleIndex((exampleIndex + 1) % examples.length)
-                }
+                onClick={() => {
+                  setExampleIndex((exampleIndex + 1) % examples.length);
+                  restartInterval();
+                }}
                 className="rounded-full p-2 text-gray-500 hover:text-black"
                 aria-label="Next example"
               >


### PR DESCRIPTION
## Summary
- rotate example prompts in an auto-playing carousel with manual controls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e3f9d23788320abfd46bbdf241380