### PR TITLE
Fix markdown table display

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -76,3 +76,28 @@ body {
 .animate-fade-in {
   animation: fade-in 0.3s ease-in-out;
 }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid #e5e7eb;
+  padding: 0.25rem 0.5rem;
+}
+
+thead {
+  background-color: #f9fafb;
+}
+
+@media (prefers-color-scheme: dark) {
+  th,
+  td {
+    border-color: #44444a;
+  }
+  thead {
+    background-color: #232326;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,6 +92,21 @@ export default function Chat() {
                     a: (props) => (
                       <a {...props} target="_blank" rel="noopener noreferrer" />
                     ),
+                    table: (props) => (
+                      <table
+                        className="w-full border-collapse overflow-auto text-left"
+                        {...props}
+                      />
+                    ),
+                    th: (props) => (
+                      <th
+                        className="border px-2 py-1 font-semibold bg-gray-50 dark:bg-gray-800"
+                        {...props}
+                      />
+                    ),
+                    td: (props) => (
+                      <td className="border px-2 py-1" {...props} />
+                    ),
                   }}
                 >
                   {message.content}


### PR DESCRIPTION
## Summary
- style markdown tables in the chat UI
- add global styles for tables

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e441e72a0832091cf2dbf51b38f46