### PR TITLE
Add icon animations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,3 +101,42 @@ thead {
     background-color: #232326;
   }
 }
+
+@keyframes icon-bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+.icon-bounce {
+  animation: icon-bounce 0.5s ease;
+}
+
+@keyframes send-wiggle {
+  0% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(15deg);
+  }
+  50% {
+    transform: rotate(-15deg);
+  }
+  75% {
+    transform: rotate(10deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+.send-icon:hover {
+  animation: send-wiggle 0.5s ease;
+}
+
+.chevron:hover {
+  animation: icon-bounce 0.5s ease;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,7 +113,7 @@ thead {
 
 .icon-bounce {
   display: inline-block;
-  animation: icon-bounce 0.5s ease;
+  animation: icon-bounce 1s ease;
 }
 
 @keyframes send-wiggle {
@@ -144,5 +144,5 @@ thead {
 }
 
 .chevron:hover {
-  animation: icon-bounce 0.5s ease;
+  animation: icon-bounce 1s ease;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,6 +112,7 @@ thead {
 }
 
 .icon-bounce {
+  display: inline-block;
   animation: icon-bounce 0.5s ease;
 }
 
@@ -131,6 +132,11 @@ thead {
   100% {
     transform: rotate(0deg);
   }
+}
+
+
+.send-icon {
+  display: inline-block;
 }
 
 .send-icon:hover {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { Bot, User, ChevronLeft, ChevronRight } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
-import { ToolCallType, getLatestToolUsage } from "./utils";
+import { getLatestToolUsage } from "./utils";
 
 const examples = [
   "Get me the top 5 stories on Hacker News in markdown table format. Use columns like title, link, score, and comments.",
@@ -28,8 +28,7 @@ const examples = [
 export default function Chat() {
   const formRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const [toolCalls, setToolCalls] = useState<Array<ToolCallType>>([]);
-  const messageNumRef = useRef(0); 
+  const messageNumRef = useRef(0);
 
   const {
     messages,
@@ -72,7 +71,6 @@ export default function Chat() {
     const toolUsage = getLatestToolUsage(messages);
     if(toolUsage && messages.length > messageNumRef.current) {
       messageNumRef.current = messages.length;
-      setToolCalls(prev => [...prev, toolUsage]);
       toast.info(
         <>
           <div>Tool Used: {toolUsage.name}</div>
@@ -113,9 +111,9 @@ export default function Chat() {
                 )}
               >
                 {message.role === "user" ? (
-                  <User width={20} />
+                  <User width={20} className="icon-bounce" />
                 ) : (
-                  <Bot width={20} />
+                  <Bot width={20} className="icon-bounce" />
                 )}
               </div>
               <div className="prose mt-1 w-full break-words prose-p:leading-relaxed">
@@ -282,7 +280,7 @@ export default function Chat() {
                 className="rounded-full p-2 text-gray-500 hover:text-black"
                 aria-label="Previous example"
               >
-                <ChevronLeft className="h-5 w-5" />
+                <ChevronLeft className="h-5 w-5 chevron" />
               </button>
               <button
                 key={exampleIndex}
@@ -302,7 +300,7 @@ export default function Chat() {
                 className="rounded-full p-2 text-gray-500 hover:text-black"
                 aria-label="Next example"
               >
-                <ChevronRight className="h-5 w-5" />
+                <ChevronRight className="h-5 w-5 chevron" />
               </button>
             </div>
           </div>
@@ -347,7 +345,7 @@ export default function Chat() {
             ) : (
               <SendIcon
                 className={clsx(
-                  "h-4 w-4",
+                  "h-4 w-4 send-icon",
                   input.length === 0 ? "text-gray-300" : "text-white",
                 )}
               />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { Bot, User, ChevronLeft, ChevronRight } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
-import { getLatestToolUsage } from "./utils";
+import { ToolCallType, getLatestToolUsage } from "./utils";
 
 const examples = [
   "Get me the top 5 stories on Hacker News in markdown table format. Use columns like title, link, score, and comments.",
@@ -29,6 +29,7 @@ export default function Chat() {
   const formRef = useRef<HTMLFormElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messageNumRef = useRef(0);
+  const [toolCalls, setToolCalls] = useState<Array<ToolCallType>>([]);
 
   const {
     messages,
@@ -68,9 +69,14 @@ export default function Chat() {
   }, []);
 
   useEffect(() => {
+    console.debug("toolCalls", toolCalls);
+  }, [toolCalls]);
+
+  useEffect(() => {
     const toolUsage = getLatestToolUsage(messages);
     if(toolUsage && messages.length > messageNumRef.current) {
       messageNumRef.current = messages.length;
+      setToolCalls(prev => [...prev, toolUsage]);
       toast.info(
         <>
           <div>Tool Used: {toolUsage.name}</div>
@@ -111,9 +117,9 @@ export default function Chat() {
                 )}
               >
                 {message.role === "user" ? (
-                  <User width={20} className="icon-bounce" />
+                  <User width={20} className="icon-bounce inline-block" />
                 ) : (
-                  <Bot width={20} className="icon-bounce" />
+                  <Bot width={20} className="icon-bounce inline-block" />
                 )}
               </div>
               <div className="prose mt-1 w-full break-words prose-p:leading-relaxed">
@@ -280,7 +286,7 @@ export default function Chat() {
                 className="rounded-full p-2 text-gray-500 hover:text-black"
                 aria-label="Previous example"
               >
-                <ChevronLeft className="h-5 w-5 chevron" />
+                <ChevronLeft className="h-5 w-5 chevron inline-block" />
               </button>
               <button
                 key={exampleIndex}
@@ -300,7 +306,7 @@ export default function Chat() {
                 className="rounded-full p-2 text-gray-500 hover:text-black"
                 aria-label="Next example"
               >
-                <ChevronRight className="h-5 w-5 chevron" />
+                <ChevronRight className="h-5 w-5 chevron inline-block" />
               </button>
             </div>
           </div>
@@ -345,7 +351,7 @@ export default function Chat() {
             ) : (
               <SendIcon
                 className={clsx(
-                  "h-4 w-4 send-icon",
+                  "h-4 w-4 send-icon inline-block",
                   input.length === 0 ? "text-gray-300" : "text-white",
                 )}
               />


### PR DESCRIPTION
## Summary
- animate bot, user, send and chevron icons
- add bounce and wiggle keyframes
- clean up unused ToolCall state

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68524b36f98c83208b1a91d0bf15851b