### PR TITLE
Add dad joke API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This demo integrates several free APIs that do not require API keys:
 - [Hacker News API](https://github.com/HackerNews/API) – fetch top stories and comments
 - [PokeAPI](https://pokeapi.co/) – get Pokémon information
 - [teehee.dev](https://teehee.dev/) – random jokes
+- [icanhazdadjoke.com](https://icanhazdadjoke.com/) – random dad jokes
 - [Scryfall](https://scryfall.com/docs/api) – random Magic: The Gathering card
 - [Cat Facts](https://catfact.ninja/) – random cat facts
 - [random.dog](https://random.dog/) – random dog images

--- a/src/app/api/chat/tools.ts
+++ b/src/app/api/chat/tools.ts
@@ -228,6 +228,25 @@ export const tools = {
     },
   }),
 
+  get_dad_joke: tool({
+    description: 'Get a random dad joke from icanhazdadjoke.com.',
+    parameters: z.object({}),
+    execute: async () => {
+      const res = await fetch('https://icanhazdadjoke.com/', {
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) {
+        throw new Error('Failed to fetch dad joke');
+      }
+      const data = await res.json();
+      const result = { joke: data.joke };
+      return {
+        ...result,
+        markdownTable: objectToMarkdownTable(result),
+      };
+    },
+  }),
+
   get_random_cat_fact: tool({
     description: 'Get a random cat fact.',
     parameters: z.object({}),

--- a/src/app/api/chat/tools.ts
+++ b/src/app/api/chat/tools.ts
@@ -239,6 +239,7 @@ export const tools = {
         throw new Error('Failed to fetch dad joke');
       }
       const data = await res.json();
+        console.log("Dad joke fetched", data);
       const result = { joke: data.joke };
       return {
         ...result,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ const examples = [
   "Summarize the comments in the top hacker news story.",
   "How tall is Metapod?",
   "Tell me a joke",
+  "Tell me a dad joke",
   "Tell me the name of a random magic card",
   "Give me a random cat fact",
   "Show me a random dog picture",
@@ -199,6 +200,16 @@ export default function Chat() {
                     className="font-medium underline underline-offset-4 transition-colors hover:text-black"
                   >
                     teehee.dev
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://icanhazdadjoke.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium underline underline-offset-4 transition-colors hover:text-black"
+                  >
+                    icanhazdadjoke
                   </a>
                 </li>
                 <li>


### PR DESCRIPTION
## Summary
- add a new `get_dad_joke` tool using icanhazdadjoke.com
- document dad joke API in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853107d8e308320ac8cb43027446778